### PR TITLE
Remove obsolete config parameter

### DIFF
--- a/cmd/rddl-2-plmnt-service/main.go
+++ b/cmd/rddl-2-plmnt-service/main.go
@@ -30,7 +30,6 @@ type MintRequestBody struct {
 }
 
 var (
-	planetmint        string
 	planetmintAddress string
 	rpcHost           string
 	rpcUser           string
@@ -200,9 +199,8 @@ func main() {
 		log.Fatalf("fatal error loading config file: %s", err)
 	}
 
-	planetmint = config.GetString("planetmint")
 	planetmintAddress = config.GetString("planetmint-address")
-	if err != nil || planetmint == "" || planetmintAddress == "" {
+	if err != nil || planetmintAddress == "" {
 		panic("Could not read configuration")
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,6 @@ package config
 import "sync"
 
 const DefaultConfigTemplate = `
-planetmint="{{ .Planetmint }}"
 planetmint-address="{{ .PlanetmintAddress }}"
 rpc-host="{{ .RPCHost }}"
 rpc-user="{{ .RPCUser }}"
@@ -16,7 +15,6 @@ wallet="{{ .Wallet }}"
 `
 
 type Config struct {
-	Planetmint        string `mapstructure:"planetmint"`
 	PlanetmintAddress string `mapstructure:"planetmint-address"`
 	RPCHost           string `mapstructure:"rpc-host"`
 	RPCUser           string `mapstructure:"rpc-user"`
@@ -37,7 +35,6 @@ var (
 // DefaultConfig returns RDDL-2-PLMNT default config
 func DefaultConfig() *Config {
 	return &Config{
-		Planetmint:        "planetmint-god",
 		PlanetmintAddress: "plmnt15xuq0yfxtd70l7jzr5hg722sxzcqqdcr8ptpl5",
 		RPCHost:           "planetmint-go-testnet-3.rddl.io:18884",
 		RPCUser:           "user",


### PR DESCRIPTION
Since we use gRPC now, we do not need the planetmint-god binary reference anymore.