### PR TITLE
69 bug one valid call to rddl 2 plmnt causes 500 lines of logs in about 8h

### DIFF
--- a/cmd/rddl-2-plmnt-service/main.go
+++ b/cmd/rddl-2-plmnt-service/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/planetmint/planetmint-go/app"
 	"github.com/planetmint/planetmint-go/lib"
-	log "github.com/rddl-network/go-logger"
+	log "github.com/rddl-network/go-utils/logger"
 	"github.com/rddl-network/rddl-2-plmnt-service/config"
 	"github.com/rddl-network/rddl-2-plmnt-service/service"
 )

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/planetmint/planetmint-go v0.6.5
 	github.com/planetmint/planetmint-go/lib v0.2.1
 	github.com/rddl-network/elements-rpc v1.0.0
-	github.com/rddl-network/go-logger v0.0.2
+	github.com/rddl-network/go-utils v0.2.2
 	github.com/spf13/viper v1.16.0
 	github.com/stretchr/testify v1.9.0
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d

--- a/go.sum
+++ b/go.sum
@@ -947,8 +947,8 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5X
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rddl-network/elements-rpc v1.0.0 h1:geFcsaD1t2ONxRC13semPpiOwsJl0ZCfkFT9UIKPZFk=
 github.com/rddl-network/elements-rpc v1.0.0/go.mod h1:E35cJMXZqe1iEo/AvjwSWn25mHZ4+y4gV8qj0lWle5c=
-github.com/rddl-network/go-logger v0.0.2 h1:Tlmatv6uROq3ZQrojU3ucJ2GeIViGIQQ2OFFLCQMXNA=
-github.com/rddl-network/go-logger v0.0.2/go.mod h1:HIWf1yOLW6nyXBxFiuVqc+YegNI9/j9RZ4u4SPWhuJ8=
+github.com/rddl-network/go-utils v0.2.2 h1:aHvb1autpzbcUwJ3aMzJJthlWSPgAJOEKPckU5XTkKw=
+github.com/rddl-network/go-utils v0.2.2/go.mod h1:wKZ1lmCGilj7jw3wylgySHz0o9puPi60HV3xS6gjPUo=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/service/backend.go
+++ b/service/backend.go
@@ -86,7 +86,7 @@ func (r2p *R2PService) convertArrivedFunds() {
 		key := iter.Key()
 		value := iter.Value()
 		msg := fmt.Sprintf("Key: %s, Value: %s\n", key, value)
-		r2p.logger.Info("msg", msg)
+		r2p.logger.Debug("msg", msg)
 		var req ConversionRequest
 		err := json.Unmarshal(value, &req)
 		if err != nil {

--- a/service/periodc_tasks_test.go
+++ b/service/periodc_tasks_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/golang/mock/gomock"
 	"github.com/planetmint/planetmint-go/util"
-	log "github.com/rddl-network/go-logger"
+	log "github.com/rddl-network/go-utils/logger"
 	"github.com/rddl-network/rddl-2-plmnt-service/config"
 	"github.com/rddl-network/rddl-2-plmnt-service/service"
 	"github.com/rddl-network/rddl-2-plmnt-service/testutil"

--- a/service/periodic_tasks.go
+++ b/service/periodic_tasks.go
@@ -67,6 +67,7 @@ func (r2p *R2PService) ExecutePotentialConversion(conversion ConversionRequest) 
 		deleteEntry = true
 		msg := "tx " + liquidTxHash + " got already minted"
 		r2p.logger.Debug("msg", msg)
+		err = errors.New(msg)
 		return
 	}
 
@@ -86,7 +87,7 @@ func (r2p *R2PService) checkMintRequest(liquidTxHash string) (code int, err erro
 	// check whether mint request already exists
 	mr, err := r2p.pmClient.CheckMintRequest(liquidTxHash)
 	if err != nil {
-		r2p.logger.Error("error", "error while fetching mint request: "+err.Error())
+		r2p.logger.Error("msg", "error while fetching mint request: "+err.Error())
 		code = http.StatusInternalServerError
 		err = fmt.Errorf("error while fetching mint request: %w", err)
 		return
@@ -94,7 +95,7 @@ func (r2p *R2PService) checkMintRequest(liquidTxHash string) (code int, err erro
 
 	// return because mint request for txhash is already
 	if mr != nil {
-		r2p.logger.Info("msg", "error while fetching mint request: txid "+liquidTxHash+" got minted before ("+mr.String()+")")
+		r2p.logger.Error("msg", "error while fetching mint request: txid "+liquidTxHash+" got minted before ("+mr.String()+")")
 		code = http.StatusConflict
 		return
 	}

--- a/service/router_test.go
+++ b/service/router_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang/mock/gomock"
-	log "github.com/rddl-network/go-logger"
+	log "github.com/rddl-network/go-utils/logger"
 	"github.com/rddl-network/rddl-2-plmnt-service/service"
 	"github.com/rddl-network/rddl-2-plmnt-service/testutil"
 	"github.com/rddl-network/rddl-2-plmnt-service/types"

--- a/service/service.go
+++ b/service/service.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	log "github.com/rddl-network/go-logger"
+	log "github.com/rddl-network/go-utils/logger"
 	"github.com/spf13/viper"
 	"github.com/syndtr/goleveldb/leveldb"
 )


### PR DESCRIPTION
- assigning error in `periodic_tasks.go::ExecutePotentialConversion(conversion ConversionRequest)` in case of `http.StatusConflict` so `deleteEntry` return value will be recognized by `backend.go::convertArrivedFunds()`

- update logging dependency so caller=<callingfile:line> is correct