### PR TITLE
reframing of log lines to be more monitoring friendly

### DIFF
--- a/service/backend.go
+++ b/service/backend.go
@@ -96,12 +96,12 @@ func (r2p *R2PService) convertArrivedFunds() {
 		deleteEntry, err := r2p.ExecutePotentialConversion(req)
 		if err != nil {
 			r2p.logger.Error("error", fmt.Sprintf("Failed to convert entry: %s - %v", string(key), err))
-			if deleteEntry {
-				r2p.logger.Info("msg", fmt.Sprintf("delete entry: %s ", string(key)))
-				err = r2p.deleteEntry(key)
-				if err != nil {
-					r2p.logger.Error("error", fmt.Sprintf("deletion of entry %s failed: %s", string(key), err.Error()))
-				}
+		}
+		if deleteEntry {
+			r2p.logger.Info("msg", fmt.Sprintf("delete entry: %s ", string(key)))
+			err = r2p.deleteEntry(key)
+			if err != nil {
+				r2p.logger.Error("error", fmt.Sprintf("deletion of entry %s failed: %s", string(key), err.Error()))
 			}
 		}
 	}

--- a/service/periodic_tasks.go
+++ b/service/periodic_tasks.go
@@ -67,7 +67,6 @@ func (r2p *R2PService) ExecutePotentialConversion(conversion ConversionRequest) 
 		deleteEntry = true
 		msg := "tx " + liquidTxHash + " got already minted"
 		r2p.logger.Debug("msg", msg)
-		err = errors.New(msg)
 		return
 	}
 
@@ -95,7 +94,7 @@ func (r2p *R2PService) checkMintRequest(liquidTxHash string) (code int, err erro
 
 	// return because mint request for txhash is already
 	if mr != nil {
-		r2p.logger.Error("msg", "error while fetching mint request: txid "+liquidTxHash+" got minted before ("+mr.String()+")")
+		r2p.logger.Debug("msg", "mint request: txid "+liquidTxHash+" got minted before ("+mr.String()+")")
 		code = http.StatusConflict
 		return
 	}


### PR DESCRIPTION
* remove error creation in case of already processed mint requests
* changed error msg to become a debug message in case of a preexisting successful minting for a given tx id
* decoupled error logging from entry deletion so that entries are even deleted if an error does appear at the same time